### PR TITLE
Support group type regex and parent indexing

### DIFF
--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/DefaultParentSelector.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/DefaultParentSelector.java
@@ -1,0 +1,45 @@
+package org.elasticsearch.transport.couchbase.capi;
+
+import org.elasticsearch.common.collect.ImmutableMap;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.Map;
+
+/**
+ * Get parent document Id according to field within document json
+ * @author tal.maayani on 1/22/2015.
+ */
+public class DefaultParentSelector implements IParentSelector {
+    protected ESLogger logger;
+
+    private ImmutableMap<String, String> documentTypeParentFields;
+
+    @Override
+    public void configure(Settings settings) {
+        this.logger = Loggers.getLogger(this.getClass(), settings, new String[0]);
+
+        this.documentTypeParentFields = settings.getByPrefix("couchbase.documentTypeParentFields.").getAsMap();
+        if (documentTypeParentFields.isEmpty()) {
+            documentTypeParentFields = null;
+        }
+        for (String key: documentTypeParentFields.keySet()) {
+            String parentField = documentTypeParentFields.get(key);
+            logger.info("Using field {} as parent for type {}", parentField, key);
+        }
+    }
+
+    @Override
+    public Object getParent(Map<String, Object> doc, String docId, String type) {
+        String parentField = null;
+        if(documentTypeParentFields != null && documentTypeParentFields.containsKey(type)) {
+            parentField = documentTypeParentFields.get(type);
+        }
+        if (parentField == null) return null;
+        if(documentTypeParentFields != null && documentTypeParentFields.containsKey(type)) {
+            parentField = documentTypeParentFields.get(type);
+        }
+        return ElasticSearchCAPIBehavior.JSONMapPath(doc, parentField);
+    }
+}

--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/GroupRegexTypeSelector.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/GroupRegexTypeSelector.java
@@ -1,0 +1,45 @@
+package org.elasticsearch.transport.couchbase.capi;
+
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Use regular expression to create document types dynamically - assuming define a named group "type" as part of regex.
+ * Use couchbase.documentTypesRegex for one regular expression configuration for all types.
+ * If you would like to use a specific type regex @use{RegexTypeSelector}
+ * Example:
+ * couchbase.documentTypesRegex: ^(?<type>\w+)::.+$
+ * @author tal.maayani on 1/23/2015.
+ */
+public class GroupRegexTypeSelector implements TypeSelector {
+    protected ESLogger logger = Loggers.getLogger(getClass());
+
+    private static final String TYPE = "type";
+    private String defaultDocumentType;
+    private Pattern documentTypesRegex;
+
+    @Override
+    public void configure(Settings settings) {
+        this.defaultDocumentType = settings.get("couchbase.defaultDocumentType", DefaultTypeSelector.DEFAULT_DOCUMENT_TYPE_DOCUMENT);
+        String documentTypesPattern = settings.get("couchbase.documentTypesRegex");
+        if (null == documentTypesPattern) {
+            logger.error("No configuration found for couchbase.documentTypesRegex, please set types regex");
+            throw new RuntimeException("No configuration found for couchbase.documentTypesRegex, please set types regex");
+        }
+        documentTypesRegex = Pattern.compile(documentTypesPattern);
+    }
+
+    @Override
+    public String getType(String index, String docId) {
+        Matcher matcher = documentTypesRegex.matcher(docId);
+        if (matcher.matches()) {
+            return matcher.group(TYPE);
+        }
+        logger.warn("Document Id {} does not match type group regex - use default document type",docId);
+        return defaultDocumentType;
+    }
+}

--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/IParentSelector.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/IParentSelector.java
@@ -1,0 +1,10 @@
+package org.elasticsearch.transport.couchbase.capi;
+
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.Map;
+
+public interface IParentSelector {
+    void configure(Settings settings);
+    Object getParent(Map<String, Object> doc, String docId, String type);
+}

--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/RegexParentSelector.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/RegexParentSelector.java
@@ -1,0 +1,74 @@
+package org.elasticsearch.transport.couchbase.capi;
+
+import org.elasticsearch.common.collect.ImmutableMap;
+import org.elasticsearch.common.logging.ESLogger;
+import org.elasticsearch.common.logging.Loggers;
+import org.elasticsearch.common.settings.Settings;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Use regular expression for parent indexing - assuming define a named group parent as part of regex.
+ * Two configurations are relevant for parent mapping:
+ * couchbase.documentTypesParentRegex - specify the parent regular expression selector. to select group name 'parent'
+ * couchbase.documentTypesParentFormat - optionally specify parent document id format
+ * for example:
+ * couchbase.documentTypesParentRegex.typeA: ^typeA::(?<parent>.+)
+ * couchbase.documentTypesParentFormat.typeA: parentType::<parent>
+ *
+ * When indexing typeA (typeA::123) document the parent is taken from typeA (123) document Id and composed into
+ * parent id according to couchbase.documentTypesParentRegex.typeA configuration. Therefore parent id that is indexed is
+ * parentType::123
+ *
+ * @author tal.maayani on 1/22/2015.
+ */
+public class RegexParentSelector implements IParentSelector {
+    public static final String PARENT = "parent";
+    protected ESLogger logger;
+    private Map<String, Pattern> documentTypeParentRegexMap;
+    private Map<String, String> documentTypeParentFormatMap;
+
+    @Override
+    public void configure(Settings settings) {
+        this.logger = Loggers.getLogger(this.getClass(), settings, new String[0]);
+
+        ImmutableMap<String, String> documentTypeParentRegexMap = settings.getByPrefix("couchbase.documentTypesParentRegex.").getAsMap();
+        ImmutableMap<String, String> documentTypeParentFormatInternalMap = settings.getByPrefix("couchbase.documentTypesParentFormat.").getAsMap();
+        this.documentTypeParentRegexMap = new HashMap<String, Pattern>();
+        this.documentTypeParentFormatMap = new HashMap<String, String>();
+        for (String key : documentTypeParentRegexMap.keySet()) {
+            String pattern = documentTypeParentRegexMap.get(key);
+            this.documentTypeParentRegexMap.put(key, Pattern.compile(pattern));
+            logger.info("Using regex {} to select parent for type {}", pattern, key);
+            if (documentTypeParentFormatInternalMap.containsKey(key)) {
+                String parentFormat = documentTypeParentFormatInternalMap.get(key);
+                logger.info("Using parent format {} to select parent of type {}",parentFormat,key);
+                documentTypeParentFormatMap.put(key,parentFormat.replace("<parent>","%s"));
+            }
+        }
+    }
+
+    @Override
+    public Object getParent(Map<String, Object> doc, String docId, String type) {
+        if (documentTypeParentRegexMap.isEmpty()) {
+            return null;
+        }
+        Pattern typePattern = documentTypeParentRegexMap.get(type);
+        if (typePattern == null) {
+            logger.trace("No parent regex found for type {}", type);
+            return null;
+        }
+        Matcher matcher = typePattern.matcher(docId);
+        if (matcher.matches()) {
+            String parent = matcher.group(PARENT);
+            if (documentTypeParentFormatMap.containsKey(type)) {
+                parent = String.format(documentTypeParentFormatMap.get(type),parent);
+            }
+            return parent;
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
1. support group type mapping by providing a regex to select type. 
   Configuration key: couchbase.documentTypesRegex
   example: 
   couchbase.documentTypesRegex: ^(?<type>\w+)::.+$
   document Id "sometype::1325" is indexed with type "sometype"  
2. Parent selector
   configuration
   couchbase.documentTypesParentRegex - per type parent regular expression to select parent 
   couchbase.documentTypesParentFormat - per type parent format that is a composition of parent selected according to regular expression.
   couchbase.parentSelector - exisitng configuration is now added a new class org.elasticsearch.transport.couchbase.capi.RegexParentSelector.

Example:
couchbase.documentTypesParentRegex.childtype: ^childtype::(?<parent>.+)
couchbase.documentTypesParentFormat.childtype: parenttype::<parent>
couchbase.parentSelector: org.elasticsearch.transport.couchbase.capi.RegexParentSelector

childtype::1234 is indexed with parent parenttype::1234
