### PR TITLE
Issue that was causing NullPointer; Removing extra code;

### DIFF
--- a/src/main/java/org/elasticsearch/transport/couchbase/capi/DefaultParentSelector.java
+++ b/src/main/java/org/elasticsearch/transport/couchbase/capi/DefaultParentSelector.java
@@ -21,9 +21,7 @@ public class DefaultParentSelector implements IParentSelector {
         this.logger = Loggers.getLogger(this.getClass(), settings, new String[0]);
 
         this.documentTypeParentFields = settings.getByPrefix("couchbase.documentTypeParentFields.").getAsMap();
-        if (documentTypeParentFields.isEmpty()) {
-            documentTypeParentFields = null;
-        }
+
         for (String key: documentTypeParentFields.keySet()) {
             String parentField = documentTypeParentFields.get(key);
             logger.info("Using field {} as parent for type {}", parentField, key);
@@ -37,9 +35,7 @@ public class DefaultParentSelector implements IParentSelector {
             parentField = documentTypeParentFields.get(type);
         }
         if (parentField == null) return null;
-        if(documentTypeParentFields != null && documentTypeParentFields.containsKey(type)) {
-            parentField = documentTypeParentFields.get(type);
-        }
+
         return ElasticSearchCAPIBehavior.JSONMapPath(doc, parentField);
     }
 }


### PR DESCRIPTION
Hello, 

We downloaded your branch with this feature and we get the following error when launching elastic:   

```
{1.3.2}: Initialization Failed 
1) NullPointerException[null]
```

We took a look at the latest merge pull request from talma/master (message: Support group type regex and parent indexing, d3605f8958e7722c462b3940b2cb76300b1bda37) and found that including this class in the yml file fixes the issue:

```
couchbase.parentSelector: org.elasticsearch.transport.couchbase.capi.RegexParentSelector
```

The problem is in DefaultParentSelector.java line 24 - 26:

```
if (documentTypeParentFields.isEmpty()) {
    documentTypeParentFields = null;
}
```

Commenting these out resolved the issue. There also appears to be a repetition on lines 40 - 42:

```
if(documentTypeParentFields != null && documentTypeParentFields.containsKey(type)) {
    parentField = documentTypeParentFields.get(type);
}
```

This code was repeated just above those lines. We'll create a pull request for this. 

Thanks, 
